### PR TITLE
Implemented connection failover

### DIFF
--- a/infinispan/client.py
+++ b/infinispan/client.py
@@ -36,7 +36,7 @@ class Infinispan(object):
     'put_async'. Async operations return :class:`concurrent.futures.Future`.
     """
 
-    def __init__(self, host="127.0.0.1", port=11222, timeout=10,
+    def __init__(self, servers=[{"host": "127.0.0.1", "port": "11222"}], timeout=10,
                  cache_name=None, key_serial=None, val_serial=None,
                  pool_size=20):
         """Initializes new client instance.
@@ -57,14 +57,14 @@ class Infinispan(object):
                           async operations.
         """
 
-        log.info("Initializing client with host=%r, port=%r, timeout=%r, "
+        log.info("Initializing client with servers=%r, timeout=%r, "
                  "cache_name=%r, key_serial=%r, val_serial=%r, pool_size=%r",
-                 host, port, timeout, cache_name, key_serial, val_serial,
+                 servers, timeout, cache_name, key_serial, val_serial,
                  pool_size)
 
         self.conn_type = connection.SocketConnection
         conn = connection.ConnectionPool(connections=[
-            self.conn_type(host, port, timeout=timeout)])
+            self.conn_type(servers, timeout=timeout)])
         self.protocol = hotrod.Protocol(conn, timeout=timeout)
         self.cache_name = cache_name
         self.ci = ClientIntelligence.TOPOLOGY

--- a/infinispan/connection.py
+++ b/infinispan/connection.py
@@ -28,7 +28,7 @@ class SocketConnection(object):
                 self._s.connect((host, port))
                 self._s.setblocking(0)
                 self.flag = 1
-                print "connected to - ", host, ":", port
+                print("connected to - ", host, ":", port)
             except socket.error:
                 self._s = None
 


### PR DESCRIPTION
issue #2 
-- multiple ip accepted as input
-- check its connectivity and flag non active as 0
-- if a ip is alive, directly connects to it, no further checks.

@VaclavDedik Please review and suggest if some change is needed
Thanks,
